### PR TITLE
Minor: Add Options.detailed option to help text

### DIFF
--- a/src/help.txt
+++ b/src/help.txt
@@ -6,6 +6,8 @@ usage: kc [options] [directory]
       include ignored files and directories
   --blame
       list all of the files for each language
+  -d
+      include more details such as blank lines
   -t, --top [number]
       only show the top few languages
   -x, --exclude [name | extension]

--- a/src/help.txt
+++ b/src/help.txt
@@ -6,7 +6,7 @@ usage: kc [options] [directory]
       include ignored files and directories
   --blame
       list all of the files for each language
-  -d
+  -d, --detailed
       include more details such as blank lines
   -t, --top [number]
       only show the top few languages


### PR DESCRIPTION
The help message displays all available options except the `Options.detailed` field. This pull request adds the field to the help text. 